### PR TITLE
update guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A PHP library for obtaining Trustpilot API access tokens",
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0 | ^7.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Allow guzzle 6 and 7 so dependent packages can migrate to guzzle 7